### PR TITLE
GetState gRPC for current state

### DIFF
--- a/chief_of_state/service.proto
+++ b/chief_of_state/service.proto
@@ -40,7 +40,7 @@ message GetStateRequest {
 }
 
 message GetStateResponse {
-  // the entity state returned after the command has been processed
+  // the current state of the entity
   google.protobuf.Any state = 1;
   // additional meta data
   MetaData meta = 2;


### PR DESCRIPTION
Adds a GET endpoint for COS that does not invoke the sidecar handler and just returns the state.

relates to namely/chief-of-state/#33