### PR TITLE
Add entity_id to state

### DIFF
--- a/chief_of_state/common.proto
+++ b/chief_of_state/common.proto
@@ -11,11 +11,12 @@ option csharp_namespace = "Namely.ChiefOfStateService.Grpc";
 import "google/protobuf/timestamp.proto";
 
 message MetaData {
+  string entity_id = 1;
   // the revision number for the entity, increases sequentially
   // this is very useful to handle optimistic lock
-  int64 revision_number = 1;
+  int64 revision_number = 2;
   // the time the state has been modified
-  google.protobuf.Timestamp revision_date = 2;
+  google.protobuf.Timestamp revision_date = 3;
   // use to store additional data.
-  map<string, string> data = 3;
+  map<string, string> data = 4;
 }


### PR DESCRIPTION
This is a **breaking change** to prepare for the lagom-pb 0.5.0 release, which adds entity_id to the metadata proto. we might as well change now.

related:
- https://github.com/super-flat/lagom-pb/pull/120
- https://github.com/super-flat/lagom-pb/blob/master/core/lagompb-core/src/main/protobuf/lagompb/core.proto#L59-L69