### PR TITLE
Wrapper for passing command to write-side with headers

### DIFF
--- a/chief_of_state/internal.proto
+++ b/chief_of_state/internal.proto
@@ -4,7 +4,7 @@ package chief_of_state;
 
 option java_package = "com.namely.protobuf.chief_of_state";
 option java_multiple_files = true;
-option java_outer_classname = "CosCommonProto";
+option java_outer_classname = "CosInternalProto";
 option go_package = "chief_of_state";
 option csharp_namespace = "Namely.ChiefOfStateService.Grpc";
 


### PR DESCRIPTION
Adds wrapper message `RemoteCommand` to pass the command and gRPC headers from the service to the write-side handler.

Relates to namely/chief-of-state#54 for 