### PR TITLE
rename "RemoteCommand" to "RemoteUnaryCall"

### DIFF
--- a/chief_of_state/internal.proto
+++ b/chief_of_state/internal.proto
@@ -23,7 +23,7 @@ message RemoteUnaryCall {
   }
 
   // the message to send
-  google.protobuf.Any argument = 1;
+  google.protobuf.Any message = 1;
 
   // the grpc headers/metadata
   repeated Header headers = 2;


### PR DESCRIPTION
we are propagating headers for write side commands and events, so this generalizes the proto name for any remote unary operation.

Relates to namely/chief-of-state#66