### PR TITLE
simplify HandleCommandResponse

### DIFF
--- a/chief_of_state/v1/writeside.proto
+++ b/chief_of_state/v1/writeside.proto
@@ -8,7 +8,6 @@ option java_outer_classname = "CosWriteSideHandlerProto";
 option go_package = "chiefofstatev1";
 option csharp_namespace = "Namely.ChiefOfState.V1";
 import "google/protobuf/any.proto";
-import "google/protobuf/empty.proto";
 import "chief_of_state/v1/common.proto";
 
 // Defines the interface that will be implemented by any application that


### PR DESCRIPTION
This PR simplifies the `HandleCommandResponse` proto. Conceptually, a command handler should accept a `Command` and result in one of the following:
- a `event` to persist to the journal
- a `no_event` or no-op, meaning the command did not change state

This change also reduces the level of nesting in the response type.