### PR TITLE
Fix warning messages during go codegen

### DIFF
--- a/chief_of_state/v1/common.proto
+++ b/chief_of_state/v1/common.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package chief_of_state.v1;
 
 option csharp_namespace = "Namely.ChiefOfState.V1";
-option go_package = "chiefofstatev1";
+option go_package = "chief_of_state/v1;chiefofstatev1";
 option java_multiple_files = true;
 option java_outer_classname = "CosCommonProto";
 option java_package = "com.namely.protobuf.chiefofstate.v1";

--- a/chief_of_state/v1/readside.proto
+++ b/chief_of_state/v1/readside.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package chief_of_state.v1;
 
 option csharp_namespace = "Namely.ChiefOfState.V1";
-option go_package = "chiefofstatev1";
+option go_package = "chief_of_state/v1;chiefofstatev1";
 option java_multiple_files = true;
 option java_outer_classname = "CosReadSideHandlerProto";
 option java_package = "com.namely.protobuf.chiefofstate.v1";

--- a/chief_of_state/v1/service.proto
+++ b/chief_of_state/v1/service.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package chief_of_state.v1;
 
 option csharp_namespace = "Namely.ChiefOfState.V1";
-option go_package = "chiefofstatev1";
+option go_package = "chief_of_state/v1;chiefofstatev1";
 option java_multiple_files = true;
 option java_outer_classname = "CosServiceProto";
 option java_package = "com.namely.protobuf.chiefofstate.v1";

--- a/chief_of_state/v1/writeside.proto
+++ b/chief_of_state/v1/writeside.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package chief_of_state.v1;
 
 option csharp_namespace = "Namely.ChiefOfState.V1";
-option go_package = "chiefofstatev1";
+option go_package = "chief_of_state/v1;chiefofstatev1";
 option java_multiple_files = true;
 option java_outer_classname = "CosWriteSideHandlerProto";
 option java_package = "com.namely.protobuf.chiefofstate.v1";


### PR DESCRIPTION
This is intended to fix the following warnings that are shown when we codegen into go:
```
     +protogen | 2020/12/09 15:57:31 WARNING: Deprecated use of 'go_package' option without a full import path in "chief_of_state/v1/common.proto", please specify:
           +protogen |  option go_package = "chief_of_state/v1;chiefofstatev1";
           +protogen | A future release of protoc-gen-go will require the import path be specified.
           +protogen | See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.
```