### PR TITLE
add an explicit go package path

### DIFF
--- a/chief_of_state/plugins/persisted_headers/v1/headers.proto
+++ b/chief_of_state/plugins/persisted_headers/v1/headers.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package chief_of_state.plugins.persisted_headers.v1;
 
 option csharp_namespace = "Namely.ChiefOfState.Plugins.PersistedHeaders.V1";
+option go_package = "chief_of_state/plugins/persisted_headers/v1;chiefofstatev1";
 option java_multiple_files = true;
 option java_outer_classname = "CosPersistedHeadersProto";
 option java_package = "com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1";


### PR DESCRIPTION
This fixes issue with latest protoc go plugin which requires the go package option