### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,6 @@
  
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/7ae850924cc44b629e79f1133e948cc9)](https://app.codacy.com/gh/namely/chief-of-state-protos/dashboard)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/7ae850924cc44b629e79f1133e948cc9)](https://app.codacy.com/gh/namely/chief-of-state-protos/dashboard)
-
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/namely/chief-of-state-protos/build/master?style=flat-square)
 
 This is the monorepo housing all the protobuf definitions of Chief Of State.

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,7 @@
 ## Chief Of State
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/7ae850924cc44b629e79f1133e948cc9)](https://app.codacy.com/gh/namely/chief-of-state-protos/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/7ae850924cc44b629e79f1133e948cc9)](https://app.codacy.com/gh/namely/chief-of-state-protos/dashboard)
 
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/namely/chief-of-state-protos/build/master?style=flat-square)
 


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.